### PR TITLE
Timestamp changed to ISO8601

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM mendersoftware/conductor:2.2.0-mender
+FROM mendersoftware/conductor:2.2.0-1-mender
 
 RUN apk update && apk add \
     python3 bash curl


### PR DESCRIPTION
https://tracker.mender.io/browse/MC-567

Timestamp change to ISO8601. mendersoftware/conductor:2.2.0-1-mender built and pushed to docker hub.