### PR TITLE
email-sender: fixed bug with wrong state reporting

### DIFF
--- a/workers/send_email/worker/main.py
+++ b/workers/send_email/worker/main.py
@@ -18,21 +18,19 @@ log = logging.getLogger()
 
 def send_email_task(task):
     try:
-        log.info("running task: " + str(task))
-        send_email.send_email(task['inputData']['email'], task['inputData']['title'], task['inputData']['body'])
+        log.info("executing task: " + str(task))
+        if not send_email.send_email(task['inputData']['email'], task['inputData']['title'], task['inputData']['body']):
+            return {'status': 'FAILED', 'output': {}, 'logs': []}
 
         # always return this well formed response - status, output, logs
-        return {'status': 'COMPLETED',
-                'output': {},
-                'logs': []}
+        return {'status': 'COMPLETED', 'output': {}, 'logs': []}
+
     except:
         log.error("failed to run task: " + str(task))
         log.fatal(traceback.format_exc())
 
         # optionally fill output/logs
-        return {'status': 'FAILED',
-                'output': {},
-                'logs': []}
+        return {'status': 'FAILED', 'output': {}, 'logs': []}
 
 
 def main():

--- a/workers/send_email/worker/send_email.py
+++ b/workers/send_email/worker/send_email.py
@@ -35,11 +35,14 @@ def send_email(recipient, title, body):
 
         log.debug("Sending email..")
         server.sendmail(conf.emailsender, recipient, message.encode("UTF8"), ['SMTPUTF8'])
-        log.debug("Email sent!")
+        log.info("Email successfully sent to '%s'" % recipient)
 
-        server.quit()
-        log.debug("Done.")
+        return True
 
     except:
         log.error("Failed to send message to '%s'" % recipient)
         log.fatal(traceback.format_exc())
+        return False
+
+    finally:
+        server.quit()


### PR DESCRIPTION
https://tracker.mender.io/browse/MC-894

When email-sender has failed to send an email it still reported to conductor COMPLETED state.

The changes are in the PR are tested by setting wrong smtp credentials and triggering proper workflow. As result email-client tries to send an email, fails and report FAILED status to conductor. After this conductor schedules the task 2 more times and when all tries are failed it marks the task as failed.
Before this change task was marked as successful after first unsuccessful execution attempt.