### PR TITLE
update conductor to 2.11.0

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM mendersoftware/conductor:2.2.0-1-mender
+FROM mendersoftware/conductor:2.11.0-1-mender
 
 RUN apk update && apk add \
     python3 bash curl

--- a/server/tasks/create_device_inventory.json
+++ b/server/tasks/create_device_inventory.json
@@ -7,6 +7,7 @@
         "outputKeys": [],
         "timeoutPolicy": "RETRY",
         "retryLogic": "EXPONENTIAL_BACKOFF",
-        "retryDelaySeconds": 60
+        "retryDelaySeconds": 60,
+        "responseTimeoutSeconds": 5
     }
 ]

--- a/server/tasks/delete_device_deployments.json
+++ b/server/tasks/delete_device_deployments.json
@@ -7,6 +7,7 @@
         "outputKeys": [],
         "timeoutPolicy": "RETRY",
         "retryLogic": "EXPONENTIAL_BACKOFF",
-        "retryDelaySeconds": 60
+        "retryDelaySeconds": 60,
+        "responseTimeoutSeconds": 5
     }
 ]

--- a/server/tasks/delete_device_inventory.json
+++ b/server/tasks/delete_device_inventory.json
@@ -7,6 +7,7 @@
         "outputKeys": [],
         "timeoutPolicy": "RETRY",
         "retryLogic": "EXPONENTIAL_BACKOFF",
-        "retryDelaySeconds": 60
+        "retryDelaySeconds": 60,
+        "responseTimeoutSeconds": 5
     }
 ]

--- a/server/workflows/decommission_device.json
+++ b/server/workflows/decommission_device.json
@@ -19,7 +19,9 @@
                                 "headers": {
                                     "X-MEN-RequestID": "${workflow.input.request_id}",
                                     "Authorization": "${workflow.input.authorization}"
-                                }
+                                },
+                                "connectionTimeOut":"1000",
+                                "readTimeOut":"1000"
                             }
                         },
                         "type": "HTTP"
@@ -36,7 +38,9 @@
                                 "headers": {
                                     "X-MEN-RequestID": "${workflow.input.request_id}",
                                     "Authorization": "${workflow.input.authorization}"
-                                }
+                                },
+                                "connectionTimeOut":"1000",
+                                "readTimeOut":"1000"
                             }
                         },
                         "type": "HTTP"

--- a/server/workflows/provision_device.json
+++ b/server/workflows/provision_device.json
@@ -15,7 +15,9 @@
                     "headers": {
                         "X-MEN-RequestID": "${workflow.input.request_id}",
                         "Authorization": "${workflow.input.authorization}"
-                    }
+                    },
+                    "connectionTimeOut":"1000",
+                    "readTimeOut":"1000"
                 }
             },
             "type": "HTTP"


### PR DESCRIPTION
Changes: 
- conductor updated from 2.2.0 to 2.11.0
- tasks definitions fixed (conductor 2.11.0 will not work with existing definitions)
- additional timeouts in conductor simple HTTP tasks introduced

Issues: https://tracker.mender.io/browse/MEN-2644