### PR TITLE
Conductor update

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,13 @@
-FROM mendersoftware/conductor:2.11.0-1-mender
+FROM mendersoftware/conductor:2.11.0
 
 RUN apk update && apk add \
     python3 bash curl
+
+# configs
+COPY ./config/* /app/config/
+
+# startup scirpt
+COPY ./docker/startup.sh /app/
 
 # tasks
 COPY ./tasks /srv/tasks

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM mendersoftware/conductor:2.2.0-1-mender
+FROM mendersoftware/conductor:2.11.0-1-mender
 
 RUN apk update && apk add \
     python3 bash curl

--- a/server/config/config.properties
+++ b/server/config/config.properties
@@ -1,0 +1,39 @@
+# Database persistence model.  Possible values are memory, redis, and dynomite.
+# If ommitted, the persistence used is memory
+#
+# memory : The data is stored in memory and lost when the server dies.  Useful for testing or demo
+# redis : non-Dynomite based redis instance
+# dynomite : Dynomite cluster.  Use this for HA configuration.
+
+db=redis
+
+# Dynomite Cluster details.
+# format is host:port:rack separated by semicolon
+workflow.dynomite.cluster.hosts=mender-redis:6379:us-east-1b
+
+# Dynomite cluster name
+workflow.dynomite.cluster.name=mender-dynomite
+
+# Namespace for the keys stored in Dynomite/Redis
+workflow.namespace.prefix=conductor
+
+# Namespace prefix for the dyno queues
+workflow.namespace.queue.prefix=conductor_queues
+
+# No. of threads allocated to dyno-queues (optional)
+queues.dynomite.threads=10
+
+# Non-quorum port used to connect to local redis.  Used by dyno-queues.
+# When using redis directly, set this to the same port as redis server
+# For Dynomite, this is 22122 by default or the local redis-server port used by Dynomite.
+queues.dynomite.nonQuorum.port=6379
+
+
+# Transport address to elasticsearch
+workflow.elasticsearch.url=mender-elasticsearch:9300
+
+# Name of the elasticsearch cluster
+workflow.elasticsearch.index.name=conductor
+
+# For single node dynomite, must be the same as 'rack'
+EC2_AVAILABILITY_ZONE=us-east-1b

--- a/server/config/log4j.properties
+++ b/server/config/log4j.properties
@@ -1,0 +1,9 @@
+# Set root logger level to INFO and its only appender to A1.
+log4j.rootLogger=INFO, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=[%d{ISO8601}] [%t] %-5p %c %x - %m%n

--- a/server/docker/startup.sh
+++ b/server/docker/startup.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# startup.sh - startup script for the server docker image
+
+echo "Starting Conductor server"
+
+# Start the server
+cd /app/libs
+echo "Property file: $CONFIG_PROP"
+echo $CONFIG_PROP
+export config_file=
+
+if [ -z "$CONFIG_PROP" ];
+  then
+    echo "Using /app/config/config.properties";
+    export config_file=/app/config/config.properties
+  else
+    echo "Using '$CONFIG_PROP'";
+    export config_file=/app/config/$CONFIG_PROP
+fi
+
+echo "Using /app/config/log4j.properties";
+
+java $CONDUCTOR_JAVA_OPTS -jar conductor-server-*-all.jar $config_file /app/config/log4j.properties

--- a/server/tasks/create_device_inventory.json
+++ b/server/tasks/create_device_inventory.json
@@ -7,6 +7,7 @@
         "outputKeys": [],
         "timeoutPolicy": "RETRY",
         "retryLogic": "EXPONENTIAL_BACKOFF",
-        "retryDelaySeconds": 60
+        "retryDelaySeconds": 60,
+        "responseTimeoutSeconds": 5
     }
 ]

--- a/server/tasks/delete_device_deployments.json
+++ b/server/tasks/delete_device_deployments.json
@@ -7,6 +7,7 @@
         "outputKeys": [],
         "timeoutPolicy": "RETRY",
         "retryLogic": "EXPONENTIAL_BACKOFF",
-        "retryDelaySeconds": 60
+        "retryDelaySeconds": 60,
+        "responseTimeoutSeconds": 5
     }
 ]

--- a/server/tasks/delete_device_inventory.json
+++ b/server/tasks/delete_device_inventory.json
@@ -7,6 +7,7 @@
         "outputKeys": [],
         "timeoutPolicy": "RETRY",
         "retryLogic": "EXPONENTIAL_BACKOFF",
-        "retryDelaySeconds": 60
+        "retryDelaySeconds": 60,
+        "responseTimeoutSeconds": 5
     }
 ]

--- a/server/workflows/decommission_device.json
+++ b/server/workflows/decommission_device.json
@@ -19,7 +19,9 @@
                                 "headers": {
                                     "X-MEN-RequestID": "${workflow.input.request_id}",
                                     "Authorization": "${workflow.input.authorization}"
-                                }
+                                },
+                                "connectionTimeOut":"1000",
+                                "readTimeOut":"1000"
                             }
                         },
                         "type": "HTTP"
@@ -36,7 +38,9 @@
                                 "headers": {
                                     "X-MEN-RequestID": "${workflow.input.request_id}",
                                     "Authorization": "${workflow.input.authorization}"
-                                }
+                                },
+                                "connectionTimeOut":"1000",
+                                "readTimeOut":"1000"
                             }
                         },
                         "type": "HTTP"

--- a/server/workflows/provision_device.json
+++ b/server/workflows/provision_device.json
@@ -15,7 +15,9 @@
                     "headers": {
                         "X-MEN-RequestID": "${workflow.input.request_id}",
                         "Authorization": "${workflow.input.authorization}"
-                    }
+                    },
+                    "connectionTimeOut":"1000",
+                    "readTimeOut":"1000"
                 }
             },
             "type": "HTTP"


### PR DESCRIPTION
Changes:
- conductor updated from 2.2.0 to 2.11.0 (based conductor image 2.11.0 has been built from Netflix/conductor 2.11.0 tag and pushed to dockerhub manually) 
- tasks definitions fixed (conductor 2.11.0 will not work with existing definitions)
- additional timeouts in conductor simple HTTP tasks introduced
- default configuration attached to the image
- startup script modified to accept logging config file and java options

Issues: https://tracker.mender.io/browse/MEN-2644